### PR TITLE
feat: Backport PR #49 to release-4.18 - Prometheus/Thanos integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ Thumbs.db
 *.bak
 *.backup
 
+
+cmd/coordination-engine/coordination-engine

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG BUILD_DATE
 ARG VCS_REF
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -ldflags="-w -s -X main.Version=${VERSION}" \
-    -o bin/coordination-engine \
+    -o /tmp/coordination-engine \
     cmd/coordination-engine/main.go
 
 # Stage 2: Create minimal runtime image
@@ -46,7 +46,7 @@ RUN microdnf install -y ca-certificates && \
 WORKDIR /app
 
 # Copy binary from builder
-COPY --from=builder /workspace/bin/coordination-engine /app/coordination-engine
+COPY --from=builder /tmp/coordination-engine /app/coordination-engine
 
 # Create non-root user
 RUN useradd -u 1001 -r -g 0 -s /sbin/nologin \

--- a/charts/coordination-engine/values-ocp-4.18.yaml
+++ b/charts/coordination-engine/values-ocp-4.18.yaml
@@ -42,3 +42,6 @@ env:
     value: "predictive-analytics-predictor"
   - name: KSERVE_TIMEOUT
     value: "10s"
+  # Prometheus integration for real-time metrics (ADR-014)
+  - name: PROMETHEUS_URL
+    value: "https://thanos-querier.openshift-monitoring.svc:9091"

--- a/charts/coordination-engine/values-ocp-4.19.yaml
+++ b/charts/coordination-engine/values-ocp-4.19.yaml
@@ -42,3 +42,6 @@ env:
     value: "predictive-analytics-predictor"
   - name: KSERVE_TIMEOUT
     value: "10s"
+  # Prometheus integration for real-time metrics (ADR-014)
+  - name: PROMETHEUS_URL
+    value: "https://thanos-querier.openshift-monitoring.svc:9091"

--- a/charts/coordination-engine/values-ocp-4.20.yaml
+++ b/charts/coordination-engine/values-ocp-4.20.yaml
@@ -42,3 +42,6 @@ env:
     value: "predictive-analytics-predictor"
   - name: KSERVE_TIMEOUT
     value: "10s"
+  # Prometheus integration for real-time metrics (ADR-014)
+  - name: PROMETHEUS_URL
+    value: "https://thanos-querier.openshift-monitoring.svc:9091"


### PR DESCRIPTION
## Summary
Backports PR #49 to release-4.18 branch.

## Original PR
Closes #49 (backport)

## Changes Included
- `.gitignore`: Add `cmd/coordination-engine/coordination-engine` binary
- `Dockerfile`: Optimize build output path (`/workspace/bin` → `/tmp`)
- `charts/coordination-engine/values-ocp-4.18.yaml`: Add `PROMETHEUS_URL` environment variable
- `charts/coordination-engine/values-ocp-4.19.yaml`: Add `PROMETHEUS_URL` environment variable
- `charts/coordination-engine/values-ocp-4.20.yaml`: Add `PROMETHEUS_URL` environment variable

## Verification

### Verify Helm Values
```bash
grep -A2 "PROMETHEUS_URL" charts/coordination-engine/values-ocp-4.18.yaml
```

### Verify Dockerfile
```bash
grep "/tmp/coordination-engine" Dockerfile
```

### Verify .gitignore
```bash
grep "cmd/coordination-engine/coordination-engine" .gitignore
```

## Related ADRs
- ADR-014: Prometheus/Thanos Observability Integration and Incident Management

## Checklist
- [x] Cherry-picked from main (commit 446d5b6)
- [x] All files backported successfully
- [x] No merge conflicts
- [x] Targeted to release-4.18 branch